### PR TITLE
Install roles in roles directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .vagrant/
 vagrant_ansible_inventory_default
 config.yml
+roles

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+roles_path = ./roles


### PR DESCRIPTION
This is to ensure the desired versions of roles are installed; the user might already
have some old ones in the global role path.

An alternative way to approach this would be to ignore `ansible.cfg` and provide an example along with an explanation. Then people can set `roles_path` (and other options) to whatever they want.