### PR TITLE
Use quotation marks for property values

### DIFF
--- a/example.drupal.make.yml
+++ b/example.drupal.make.yml
@@ -5,12 +5,12 @@ api: 2
 # variable inside config.yml if you change the major version in this file.
 
 # Drupal core (major version, e.g. 6.x, 7.x, 8.x).
-core: 8.x
+core: "8.x"
 
 projects:
 
   drupal:
-    type: core
-    version: 8.0.x
+    type: "core"
+    version: "8.0.x"
 
-  devel: 1.x-dev
+  devel: "1.x-dev"


### PR DESCRIPTION
It seems like Drush is fine with some non-quoted property values, but has problems with others. Here is an example where I modified this default make file and ended up with problems:
https://gist.github.com/mchelen/0a2aa697ca208e94c684

For the sake of consistency, maybe it is best to use quotation marks for all values?